### PR TITLE
Add delete functionality to ReplicationBuilder

### DIFF
--- a/src/replicator.ts
+++ b/src/replicator.ts
@@ -40,6 +40,15 @@ export class ReplicationBuilder<T> {
         return new PropertyModifier<ReplicationBuilder<T>, T[K]>(this, childNode, this.replica)
     }
 
+    delete<K extends keyof T>(childNode: K): ReplicationBuilder<T> {
+        if (this.replica[childNode]) {
+            delete this.replica[childNode]
+        }
+
+        return this;
+    }
+
+
     /**
      * produces the replica
      * @returns {T} replica
@@ -56,7 +65,7 @@ export class ReplicationBuilder<T> {
  * Operator for nodes of the replica
  */
 export class ReplicaChildOperator<RT, T> {
-    private buildFunction: ()=>RT
+    private buildFunction: () => RT
     private node: T
     private replica: RT;
     private relativePath;
@@ -81,12 +90,20 @@ export class ReplicaChildOperator<RT, T> {
         return new PropertyModifier<ReplicaChildOperator<RT, T>, T[K]>(this, this.relativePath + '.' + childNode, this.replica)
     }
 
+    delete<K extends keyof T>(childNode: K): ReplicaChildOperator<RT, T> {
+        if (this.node[childNode]) {
+            delete this.node[childNode]
+        }
+
+        return this;
+    }
+
     /**
      * produces the replica
      * @returns {RT} replica
      */
-    build():RT {
-      return this.buildFunction()
+    build(): RT {
+        return this.buildFunction()
     }
 }
 

--- a/src/tests/replicator.spec.ts
+++ b/src/tests/replicator.spec.ts
@@ -21,6 +21,22 @@ describe('ReplicationBuilder', () => {
         expect(manipulatedRoot.subTypeA.subTypeB.subTypeBAttribute).to.equal('Test')
     })
 
+    it('Inputstate must not be modified, output node must be deleted', () => {
+        let rootState = new ClassorientedTeststate()
+        let manipulatedRoot = ReplicationBuilder.forObject(rootState).delete("subTypeA").build()
+
+        expect(rootState.subTypeA).to.exist
+        expect(manipulatedRoot.subTypeA).to.not.exist
+    })
+
+    it('Inputstate must not be modified, output child node must be deleted', () => {
+        let rootState = new ClassorientedTeststate()
+        let manipulatedRoot = ReplicationBuilder.forObject(rootState).getChild("subTypeA").delete("subTypeB").build()
+
+        expect(rootState.subTypeA.subTypeB).to.exist
+        expect(manipulatedRoot.subTypeA.subTypeB).to.not.exist
+    })
+
     it('with untyped structure: Inputstate must not be modified, output must be modified', () => {
         let rootState = SimpleTeststate
         let manipulatedRoot = ReplicationBuilder.forObject(rootState).getChild('subTypeB').modify("subtypeBAttribute").to('Test').build()


### PR DESCRIPTION
This functionality allows it to delete properties from an object